### PR TITLE
feat: ask user to input WaniKani API Key

### DIFF
--- a/components/APIKeyDialog.tsx
+++ b/components/APIKeyDialog.tsx
@@ -1,0 +1,34 @@
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Link from '@mui/material/Link';
+
+const WANIKANI_TOKEN_LINK = "https://www.wanikani.com/settings/personal_access_tokens";
+
+export default function APIKeyDialog({isOpen}: {isOpen: boolean}) {
+    return (
+        <Dialog open={isOpen}>
+        <DialogTitle>Please input your WaniKani API Key</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            We currently fetch Japanese sentences from WaniKani. If you already have a WaniKani account, your API Key can be found <Link target="_blank" rel="noopener" href={WANIKANI_TOKEN_LINK}>here</Link>.
+          </DialogContentText>
+          <TextField
+            autoFocus
+            margin="dense"
+            id="wanikani-api-key"
+            label="WaniKani APIv2 Key"
+            fullWidth
+            variant="standard"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button>Proceed</Button>
+        </DialogActions>
+      </Dialog>
+    );
+}

--- a/components/APIKeyDialog.tsx
+++ b/components/APIKeyDialog.tsx
@@ -6,29 +6,73 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Link from '@mui/material/Link';
+import { useState } from "react";
 
 const WANIKANI_TOKEN_LINK = "https://www.wanikani.com/settings/personal_access_tokens";
+const API_KEY_LENGTH = 36;
+const INVALID_API_KEY_ERROR_MESSAGE = "Invalid API key";
+const isValidAPIKey = (apiKey: string) => {
+  const regexExpForUUID = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+  return regexExpForUUID.test(apiKey);
+}
 
 export default function APIKeyDialog({isOpen}: {isOpen: boolean}) {
-    return (
-        <Dialog open={isOpen}>
-        <DialogTitle>Please input your WaniKani API Key</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            We currently fetch Japanese sentences from WaniKani. If you already have a WaniKani account, your API Key can be found <Link target="_blank" rel="noopener" href={WANIKANI_TOKEN_LINK}>here</Link>.
-          </DialogContentText>
-          <TextField
-            autoFocus
-            margin="dense"
-            id="wanikani-api-key"
-            label="WaniKani APIv2 Key"
-            fullWidth
-            variant="standard"
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button>Proceed</Button>
-        </DialogActions>
-      </Dialog>
-    );
+  const [validableAPIKey, setValidableAPIKey] = useState<{
+    value: string,
+    isValid: boolean,
+    errorMessage: string,
+  }>({
+    value: "",
+    isValid: false,
+    errorMessage: "",
+  });
+
+  const onAPIKeyTextFieldChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const isValid = isValidAPIKey(value);
+    const errorMessage = value.length === API_KEY_LENGTH && !isValid ? INVALID_API_KEY_ERROR_MESSAGE : "";
+
+    setValidableAPIKey(prevState => ({
+      ...prevState,
+      value,
+      isValid,
+      errorMessage,
+    }));
+  };
+
+  const onAPIKeyTextFieldBlur = (_: React.FocusEvent<HTMLInputElement>) => {
+    setValidableAPIKey(prevState => ({
+      ...prevState,
+      errorMessage: prevState.isValid ? "" : INVALID_API_KEY_ERROR_MESSAGE,
+    }));
+  };
+  const {value, isValid, errorMessage} = validableAPIKey;
+
+  return (
+      <Dialog open={isOpen}>
+      <DialogTitle>Please input your WaniKani API Key</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          We currently fetch Japanese sentences from WaniKani. If you already have a WaniKani account, your API Key can be found <Link target="_blank" rel="noopener" href={WANIKANI_TOKEN_LINK}>here</Link>.
+        </DialogContentText>
+        <TextField
+          autoFocus
+          required
+          error={errorMessage !== ""}
+          helperText={errorMessage}
+          margin="dense"
+          id="wanikani-api-key"
+          label="WaniKani APIv2 Key"
+          fullWidth
+          variant="standard"
+          value={value}
+          onChange={onAPIKeyTextFieldChange}
+          onBlur={onAPIKeyTextFieldBlur}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button disabled={!isValid}>Proceed</Button>
+      </DialogActions>
+    </Dialog>
+  );
 }

--- a/components/APIKeyDialog.tsx
+++ b/components/APIKeyDialog.tsx
@@ -16,7 +16,7 @@ const isValidAPIKey = (apiKey: string) => {
   return regexExpForUUID.test(apiKey);
 }
 
-export default function APIKeyDialog({isOpen}: {isOpen: boolean}) {
+export default function APIKeyDialog({isOpen, onSubmit}: {isOpen: boolean, onSubmit: (apiKey: string) => void}) {
   const [validableAPIKey, setValidableAPIKey] = useState<{
     value: string,
     isValid: boolean,
@@ -46,7 +46,18 @@ export default function APIKeyDialog({isOpen}: {isOpen: boolean}) {
       errorMessage: prevState.isValid ? "" : INVALID_API_KEY_ERROR_MESSAGE,
     }));
   };
+
   const {value, isValid, errorMessage} = validableAPIKey;
+
+  const proceedButtonOnClick = () => {
+    onSubmit(value);
+    // clear state
+    setValidableAPIKey({
+      value: "",
+      isValid: false,
+      errorMessage: "",
+    });
+  }
 
   return (
       <Dialog open={isOpen}>
@@ -72,7 +83,7 @@ export default function APIKeyDialog({isOpen}: {isOpen: boolean}) {
         />
       </DialogContent>
       <DialogActions>
-        <Button disabled={!isValid}>Proceed</Button>
+        <Button disabled={!isValid} onClick={proceedButtonOnClick}>Proceed</Button>
       </DialogActions>
     </Dialog>
   );

--- a/components/APIKeyDialog.tsx
+++ b/components/APIKeyDialog.tsx
@@ -68,6 +68,7 @@ export default function APIKeyDialog({isOpen}: {isOpen: boolean}) {
           value={value}
           onChange={onAPIKeyTextFieldChange}
           onBlur={onAPIKeyTextFieldBlur}
+          inputProps={{maxLength: API_KEY_LENGTH}}
         />
       </DialogContent>
       <DialogActions>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import {useState} from 'react';
 import { CssBaseline } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import { useSentence } from '../libs/sentence';
+import APIKeyDialog from '../components/APIKeyDialog';
 
 const Home: NextPage = () => {
   const [isEnglishVisible, setIsEnglishVisible] = useState<Boolean>(false);
@@ -29,21 +30,22 @@ const Home: NextPage = () => {
       <Typography sx={{marginTop: 4}} variant="body2" color="text.secondary" align="center">１文ずつ</Typography>
       <Typography variant="body2" color="text.secondary" align="center">Ichi Bun Zutsu</Typography>
 
-      
-        <Paper sx={{ my: { xs: 3, md: 6 }, p: { xs: 2, md: 3 }}}>
-          {sentence && (
-            <>
-              <Typography component="h1" variant="h4" align="center">{sentence['ja']}</Typography>
-              {isEnglishVisible && <Typography variant="h5" align="center">{sentence['en']}</Typography>}
-              {!isEnglishVisible && <Button onClick={showEnglishButtonOnClick} variant="contained" fullWidth>英語を表示</Button>}
-            </>
-          )}
-          {isLoading && (
-            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-              <CircularProgress />
-            </Box>
-          )}
-        </Paper>
+      <Paper sx={{ my: { xs: 3, md: 6 }, p: { xs: 2, md: 3 }}}>
+        {sentence && (
+          <>
+            <Typography component="h1" variant="h4" align="center">{sentence['ja']}</Typography>
+            {isEnglishVisible && <Typography variant="h5" align="center">{sentence['en']}</Typography>}
+            {!isEnglishVisible && <Button onClick={showEnglishButtonOnClick} variant="contained" fullWidth>英語を表示</Button>}
+          </>
+        )}
+        {isLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress />
+          </Box>
+        )}
+      </Paper>
+
+      <APIKeyDialog isOpen={true} />
       
     </Container>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,8 @@ import APIKeyDialog from '../components/APIKeyDialog';
 
 const Home: NextPage = () => {
   const [isEnglishVisible, setIsEnglishVisible] = useState<Boolean>(false);
-  const {sentence, isLoading} = useSentence();
+  const [apiKey, setAPIKey] = useState<string | null>(null);
+  const {sentence, isLoading, isError} = useSentence(apiKey);
 
   const showEnglishButtonOnClick: () => void = () => {
     setIsEnglishVisible(true);
@@ -38,14 +39,22 @@ const Home: NextPage = () => {
             {!isEnglishVisible && <Button onClick={showEnglishButtonOnClick} variant="contained" fullWidth>英語を表示</Button>}
           </>
         )}
-        {isLoading && (
+        {(isLoading || !apiKey)&& (
           <Box sx={{ display: 'flex', justifyContent: 'center' }}>
             <CircularProgress />
           </Box>
         )}
+        {(isError && !isLoading && apiKey) && (
+          <>
+            <Typography variant="h5" align="center">Could not fetch sentence from WaniKani</Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <Button variant="contained" onClick={() => setAPIKey(null)}>Retry</Button>
+            </Box>
+          </>
+        )}
       </Paper>
 
-      <APIKeyDialog isOpen={true} />
+      <APIKeyDialog isOpen={!apiKey} onSubmit={(apiKey) => setAPIKey(apiKey)} />
       
     </Container>
   );


### PR DESCRIPTION


https://user-images.githubusercontent.com/169272/197971938-128938af-3ba8-468b-b835-4f2611ee9afa.mov


- Show a dialog to ask the user to input WaniKani API Key
- Apply front-end validation (UUID v4) to the input field
- Pass the inputted API Key to WaniKani API endpoint through the SWR call 
- Show an error message when fetching fails -- giving the user an option to retry and reinput the API Key

