### PR TITLE
feat: persist WaniKani API Key to browser's local storage

### DIFF
--- a/libs/hooks/useAPIKey.ts
+++ b/libs/hooks/useAPIKey.ts
@@ -1,0 +1,36 @@
+import {useState} from 'react';
+
+const localStorageKey = "WANIKANI_API_KEY";
+
+// Reference: https://usehooks.com/useLocalStorage/
+export default function useAPIKey() {
+    const [storedAPIKey, setStoredAPIKey] = useState<string | null>(() => {
+        if (typeof window === "undefined") {
+            return null;
+        }
+
+        try {
+            const apiKey = window.localStorage.getItem(localStorageKey);
+            return apiKey ?? null;
+        } catch (error) {
+            return null;
+        }
+    });
+
+    const setAPIKey = (value: string | null) => {
+        try {
+            setStoredAPIKey(value);
+            if (typeof window !== "undefined") {
+                if (value === null) {
+                    window.localStorage.removeItem(localStorageKey);
+                } else {
+                    window.localStorage.setItem(localStorageKey, value);
+                }
+            }
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
+    return [storedAPIKey, setAPIKey] as const;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,10 +10,11 @@ import { CssBaseline } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import { useSentence } from '../libs/sentence';
 import APIKeyDialog from '../components/APIKeyDialog';
+import useAPIKey from '../libs/hooks/useAPIKey';
 
 const Home: NextPage = () => {
   const [isEnglishVisible, setIsEnglishVisible] = useState<Boolean>(false);
-  const [apiKey, setAPIKey] = useState<string | null>(null);
+  const [apiKey, setAPIKey] = useAPIKey();
   const {sentence, isLoading, isError} = useSentence(apiKey);
 
   const showEnglishButtonOnClick: () => void = () => {


### PR DESCRIPTION
create a hook `useAPIKey` for storing WaniKani API Key. The is basically a wrapper around the `useState` hook while also persisting the API key to `window.localStorage`.

Reference: https://usehooks.com/useLocalStorage/