### PR TITLE
Fetch WaniKani sentence via API Routes

### DIFF
--- a/pages/api/sentence.ts
+++ b/pages/api/sentence.ts
@@ -1,8 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const SHEETSON_URL: string = 'https://api.sheetson.com/v2/sheets/';
+//TODO: sync level with user's level
+const WANIKANI_URL: string = 'https://api.wanikani.com/v2/subjects?types=vocabulary&levels=1,2,3';
 
-type Sentence = {
+export type Sentence = {
     en: string,
     ja: string,
 };
@@ -13,7 +15,7 @@ const getRandomInt = (min: number, max: number) => {
     return Math.floor(Math.random() * (max - min) + min); // The maximum is exclusive and the minimum is inclusive
 };
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse<Sentence | {error: string}>) {
+const fetchFromSheetson = () => {
     const params = {
         spreadsheetId: process.env.SHEETSON_SPREADHEET_ID || "",
         apiKey: process.env.SHEETSON_API_KEY || "",
@@ -21,32 +23,69 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const urlSearchParams = new URLSearchParams(params);
     const sentenceCountAPIUrl = `${SHEETSON_URL}SentenceCount/2?${urlSearchParams}`;
 
+    return fetch(sentenceCountAPIUrl)
+        .then(res => res.json())
+        .then(data => {
+            if (data?.count) {
+                const sentenceCount = Number.parseInt(data.count);
+                if (!Number.isNaN(sentenceCount)) {
+                    const randomSentenceId = getRandomInt(2, sentenceCount + 1); // data starts from row 2
+                    const sentenceAPIUrl = `${SHEETSON_URL}Sentences/${randomSentenceId}?${urlSearchParams}`;
+                    return fetch(sentenceAPIUrl);
+                }
+            }
+            return Promise.reject("Error fetching sentence");
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data?.ja && data?.en) {
+                return {
+                    "en": data.en,
+                    "ja": data.ja,
+                };
+            }
+
+            return Promise.reject("Error fetching sentence");
+    });
+}
+
+const fetchFromWaniKani = (apiKey: string | null) => {
+    if (!apiKey) {
+        return Promise.reject('API Key is required');
+    }
+
+    return fetch(WANIKANI_URL, {
+        headers: {
+            'Authorization': `Bearer ${apiKey}` 
+        }
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data?.error) {
+            return Promise.reject(data.error);
+        }
+
+        // randomized sentence
+        if (data?.data && data.data.length > 0) {
+            const randomVocabIndex = getRandomInt(0, data.data.length);
+            const randomVocabContextSentences = data.data[randomVocabIndex].data['context_sentences'];
+            if (randomVocabContextSentences.length > 0) {
+                const randomSentenceIndex = getRandomInt(0, randomVocabContextSentences.length);
+                return randomVocabContextSentences[randomSentenceIndex];
+            }
+        } else {
+            return Promise.reject("Error fetching sentence");
+        }
+    });
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Sentence | {error: string}>) {
+    const {shouldFetchFromWaniKani: shouldFetchFromWaniKaniParam = false, waniKaniAPIKey: waniKaniAPIKeyParam = null} = req.query;
+    const shouldFetchFromWaniKani = Array.isArray(shouldFetchFromWaniKaniParam) ? shouldFetchFromWaniKaniParam[0] === "true" : shouldFetchFromWaniKaniParam === "true";
+    const waniKaniAPIKey = Array.isArray(waniKaniAPIKeyParam) ? waniKaniAPIKeyParam[0] : waniKaniAPIKeyParam;
+
     try {
-        const data = await fetch(sentenceCountAPIUrl)
-            .then(res => res.json())
-            .then(data => {
-                if (data?.count) {
-                    const sentenceCount = Number.parseInt(data.count);
-                    if (!Number.isNaN(sentenceCount)) {
-                        const randomSentenceId = getRandomInt(2, sentenceCount + 1); // data starts from row 2
-                        const sentenceAPIUrl = `${SHEETSON_URL}Sentences/${randomSentenceId}?${urlSearchParams}`;
-                        return fetch(sentenceAPIUrl);
-                    }
-                }
-                return Promise.reject("Error fetching sentence");
-            })
-            .then(res => res.json())
-            .then(data => {
-                if (data?.ja && data?.en) {
-                    return {
-                        "en": data.en,
-                        "ja": data.ja,
-                    };
-                }
-
-                return Promise.reject("Error fetching sentence");
-            });
-
+        const data = await (shouldFetchFromWaniKani ? fetchFromWaniKani(waniKaniAPIKey) : fetchFromSheetson());
         res.status(200).json(data);
     } catch (error) {
         const errorString: string = error as string;


### PR DESCRIPTION
Make `/api/sentence` to accept query params: `shouldFetchFromWaniKani` and `waniKaniAPIKey`.
When `shouldFetchFromWaniKani=true` is passed, the API should fetch from WaniKani API instead from Google Sheets (sheetson)