### PR TITLE
feat: filter fetched context sentences according to WaniKani level

### DIFF
--- a/pages/api/sentence.ts
+++ b/pages/api/sentence.ts
@@ -1,7 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const SHEETSON_URL: string = 'https://api.sheetson.com/v2/sheets/';
-//TODO: sync level with user's level
 const WANIKANI_API_URL: string = 'https://api.wanikani.com/v2';
 const WANIKANI_SUBJECT_ENDPOINT: string = `${WANIKANI_API_URL}/subjects`;
 const WANIKANI_USER_ENDPOINT: string = `${WANIKANI_API_URL}/user`;


### PR DESCRIPTION
Add an additional fetch call to WaniKani API to get the user's `level`. We also have to comply with user's WaniKani subscription status, quoting from [1]:

> `max_level_granted` - The maximum level of content accessible to the user for lessons, reviews, and content review. For unsubscribed/free users, the maximum level is 3. For subscribed users, this is 60. Any application that uses data from the WaniKani API must respect these access limits.

Then, fetch WaniKani subjects according to the user level by randomizing the `levels` (ref: [2]) query parameter between 1 and user's current level.

References:
[1] [WaniKani User Data Structure](https://docs.api.wanikani.com/20170710/#user-data-structure) -- note the `level` attribute of the **User Data Structure** and the `max_level_granted` attribute of the **Subscription Object Attributes**
[2] [WaniKani Subjects API](https://docs.api.wanikani.com/20170710/#get-all-subjects) -- note the `levels` parameter