### PR TITLE
feat: show furigana on hover or click

### DIFF
--- a/libs/sentence.tsx
+++ b/libs/sentence.tsx
@@ -1,6 +1,8 @@
 import useSWRImmutable from "swr/immutable";
 import type {Sentence} from "../pages/api/sentence";
-import parse, {HTMLReactParserOptions, Element, domToReact} from 'html-react-parser';
+import {useState} from "react";
+import parse, {HTMLReactParserOptions, domToReact, Element, Text} from 'html-react-parser';
+import {ElementType} from "domelementtype";
 
 const SENTENCE_API_ENDPOINT: string = "/api/sentence";
 
@@ -36,21 +38,66 @@ export const useSentence:
     };
 };
 
-export const JapaneseSentenceElement = ({sentence, showFurigana = true} : {sentence: Sentence, showFurigana?: boolean}) => {
+const KanjiFuriganaElement = ({kanji, furigana}: {kanji: string, furigana: string}) => {
+    const [shouldShowFurigana, setShouldShowFurigana] = useState<boolean>(false);
+    const [alwaysShowFurigana, setAlwaysShowFurigana] = useState<boolean>(false);
+    const showFurigana = () => {
+        if (!alwaysShowFurigana) {
+            setShouldShowFurigana(true);
+        }
+    };
+    const hideFurigana = () => {
+        if (!alwaysShowFurigana) {
+            setShouldShowFurigana(false);
+        }
+    };
+    const toggleFurigana = () => {
+        // When the kanji is clicked, we always show the furigana unless it's clicked again
+        setAlwaysShowFurigana(prevValue => !prevValue);
+    };
+
+    return <ruby onMouseEnter={showFurigana} onMouseLeave={hideFurigana} onClick={toggleFurigana}>
+        {kanji}
+        <rp>(</rp>
+        <rt className={shouldShowFurigana ? 'show-furigana' : 'hide-furigana'}>
+            {furigana}
+        </rt>
+        <rp>)</rp>
+        <style jsx>{`
+            ruby {
+                cursor: pointer;
+            }
+            rt.show-furigana {
+                opacity: 1;
+            }
+            rt.hide-furigana {
+                opacity: 0;
+            }
+        `}</style>
+    </ruby>;
+}
+
+export const JapaneseSentenceElement = ({sentence} : {sentence: Sentence}) => {
     const parseFuriganaOptions: HTMLReactParserOptions = {
         replace: domNode => {
-            if (domNode instanceof Element && domNode.name === 'rt') {
-                return <rt className={showFurigana ? 'show-furigana' : 'hide-furigana'}>
-                    {domToReact(domNode.children, parseFuriganaOptions)}
-                    <style jsx>{`
-                        .show-furigana {
-                            opacity: 1;
-                        }
-                        .hide-furigana {
-                            opacity: 0;
-                        }
-                    `}</style>
-                </rt>
+            if (domNode instanceof Element && domNode.name === 'ruby') {
+                let kanji = "";
+                let furigana = "";
+                // find the kanji
+                const kanjiNode = domNode.children.find((node) => node.type === ElementType.Text); 
+                if (kanjiNode) {
+                    kanji = (kanjiNode as Text).data;
+                }
+
+                const furiganaWrapperNode = domNode.children.find((node) => node instanceof Element && node.name === 'rt');
+                if (furiganaWrapperNode instanceof Element) {
+                    const furiganaNode = (furiganaWrapperNode as Element).children.find((node) => node.type === ElementType.Text);
+                    if (furiganaNode) {
+                        furigana = (furiganaNode as Text).data;
+                    }
+                }
+
+                return <KanjiFuriganaElement kanji={kanji} furigana={furigana} />;
             }
         }
     }

--- a/libs/sentence.tsx
+++ b/libs/sentence.tsx
@@ -77,31 +77,31 @@ const KanjiFuriganaElement = ({kanji, furigana}: {kanji: string, furigana: strin
     </ruby>;
 }
 
-export const JapaneseSentenceElement = ({sentence} : {sentence: Sentence}) => {
-    const parseFuriganaOptions: HTMLReactParserOptions = {
-        replace: domNode => {
-            if (domNode instanceof Element && domNode.name === 'ruby') {
-                let kanji = "";
-                let furigana = "";
-                // find the kanji
-                const kanjiNode = domNode.children.find((node) => node.type === ElementType.Text); 
-                if (kanjiNode) {
-                    kanji = (kanjiNode as Text).data;
-                }
-
-                const furiganaWrapperNode = domNode.children.find((node) => node instanceof Element && node.name === 'rt');
-                if (furiganaWrapperNode instanceof Element) {
-                    const furiganaNode = (furiganaWrapperNode as Element).children.find((node) => node.type === ElementType.Text);
-                    if (furiganaNode) {
-                        furigana = (furiganaNode as Text).data;
-                    }
-                }
-
-                return <KanjiFuriganaElement kanji={kanji} furigana={furigana} />;
+const parseFuriganaOptions: HTMLReactParserOptions = {
+    replace: domNode => {
+        if (domNode instanceof Element && domNode.name === 'ruby') {
+            let kanji = "";
+            let furigana = "";
+            // find the kanji
+            const kanjiNode = domNode.children.find((node) => node.type === ElementType.Text); 
+            if (kanjiNode) {
+                kanji = (kanjiNode as Text).data;
             }
+
+            const furiganaWrapperNode = domNode.children.find((node) => node instanceof Element && node.name === 'rt');
+            if (furiganaWrapperNode instanceof Element) {
+                const furiganaNode = (furiganaWrapperNode as Element).children.find((node) => node.type === ElementType.Text);
+                if (furiganaNode) {
+                    furigana = (furiganaNode as Text).data;
+                }
+            }
+
+            return <KanjiFuriganaElement kanji={kanji} furigana={furigana} />;
         }
     }
+}
 
+export const JapaneseSentenceElement = ({sentence} : {sentence: Sentence}) => {
     if (sentence.furiganaHTML) {
         return <>
             {parse(sentence.furiganaHTML, parseFuriganaOptions)}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,15 +14,10 @@ import type { SettingsType } from '../components/SettingsDialog';
 import useSavedSettings from '../libs/hooks/useSavedSettings';
 
 const Home: NextPage = () => {
-  const [isFuriganaVisible, setIsFuriganaVisible] = useState<boolean>(false);
   const [isEnglishVisible, setIsEnglishVisible] = useState<boolean>(false);
   const [savedSettings, setSavedSettings] = useSavedSettings();
   const {isWaniKaniEnabled, waniKaniAPIKey} = savedSettings || {};
   const {sentence, isLoading, isError, refetch} = useSentence(waniKaniAPIKey, isWaniKaniEnabled);
-
-  const showFuriganaButtonOnClick: () => void = () => {
-    setIsFuriganaVisible(true);
-  };
 
   const showEnglishButtonOnClick: () => void = () => {
     setIsEnglishVisible(true);
@@ -31,7 +26,6 @@ const Home: NextPage = () => {
   const refetchSentence = () => {
     refetch();
     setIsEnglishVisible(false);
-    setIsFuriganaVisible(false);
   };
 
   const errorRetryHandler = () => {
@@ -62,18 +56,16 @@ const Home: NextPage = () => {
       <Paper sx={{ my: { xs: 3, md: 6 }, p: { xs: 2, md: 3 }}}>
         {sentenceIsLoaded && (
           <>
-            <Typography component="h1" variant="h4" align="center"><JapaneseSentenceElement sentence={sentence} showFurigana={isFuriganaVisible} /></Typography>
-            {!isFuriganaVisible && (
-              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                <Button onClick={showFuriganaButtonOnClick} variant="contained">Show Furigana</Button>
-              </Box>
-            )}
+            <Typography component="h1" variant="h4" align="center"><JapaneseSentenceElement sentence={sentence} /></Typography>
             {isEnglishVisible && <Typography variant="h5" align="center">{sentence['en']}</Typography>}
-            {(isFuriganaVisible && !isEnglishVisible) && (
+            {!isEnglishVisible && (
               <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                 <Button onClick={showEnglishButtonOnClick} variant="contained">Show English</Button>
               </Box>
             )}
+            <Box sx={{ fontStyle: 'italic', marginTop: 2, display: 'flex', justifyContent: 'center' }}>
+              <Typography variant="caption">Hover or click on any kanji to show furigana</Typography>
+            </Box>
           </>
         )}
         {(isLoading || (!savedSettings)) && (


### PR DESCRIPTION
- Create a `KanjiFuriganaElement` that would hide/show furigana on hover. Clicking on the kanji would "hold" the furigana to be shown as always.
- Replace the ruby element with this `KanjiFuriganaElement` when parsing `furiganaHTML` from the fetched sentence.
- Remove `Show Furigana` button on the main page; add a caption text on how to show furigana.