### PR TITLE
feat: add dark mode settings

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -8,8 +8,11 @@ import DialogTitle from '@mui/material/DialogTitle';
 import Link from '@mui/material/Link';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
-import { useState } from "react";
+import { useContext, useState } from "react";
 import type { SavedSettings } from '../libs/hooks/useSavedSettings';
+import { useTheme } from '@mui/material/styles';
+import { Divider, Typography } from '@mui/material';
+import ThemeContext from './ThemeContext';
 
 const WANIKANI_TOKEN_LINK = "https://www.wanikani.com/settings/personal_access_tokens";
 const TATOEBA_LINK = "https://tatoeba.org";
@@ -57,7 +60,10 @@ export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings
     validableAPIKey: savedSettings?.waniKaniAPIKey ? {value: savedSettings?.waniKaniAPIKey, isValid: isValidAPIKey(savedSettings?.waniKaniAPIKey), errorMessage: ""} : undefined,
   };
   const [settings, setSettings] = useState<SettingsType>(initialSettings);
-
+  const {palette: {mode: themeMode}} = useTheme();
+  const isDarkModeEnabled = themeMode === 'dark';
+  const themeContext = useContext(ThemeContext);
+  
   const onWaniKaniIntegrationChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSettings(prevState => {
       const isValidableAPIKey = prevState.validableAPIKey ?? {
@@ -116,7 +122,13 @@ export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings
       <Dialog open={isOpen} onClose={onDialogClose}>
       <DialogTitle>Settings</DialogTitle>
       <DialogContent>
-        <FormControlLabel control={<Switch checked={isWaniKaniEnabled} onChange={onWaniKaniIntegrationChanged} />} label={`WaniKani integration is ${isWaniKaniEnabled ? 'enabled' : 'disabled'}`} />
+        <Typography variant="subtitle1" gutterBottom>
+          Sentence Source
+        </Typography>
+        <FormControlLabel 
+          control={<Switch checked={isWaniKaniEnabled} 
+          onChange={onWaniKaniIntegrationChanged} />} 
+          label={`WaniKani integration is ${isWaniKaniEnabled ? 'enabled' : 'disabled'}`} />
         <SettingsDialogTextGroup isWaniKaniEnabled={isWaniKaniEnabled} />  
         {isWaniKaniEnabled && <TextField
           autoFocus
@@ -133,6 +145,14 @@ export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings
           onBlur={onAPIKeyTextFieldBlur}
           inputProps={{maxLength: API_KEY_LENGTH}}
         />}
+        <Divider sx={{marginBottom: 2}} />
+        <Typography variant="subtitle1" gutterBottom>
+          Appearance
+        </Typography>
+        <FormControlLabel 
+          control={<Switch checked={isDarkModeEnabled} 
+          onChange={themeContext.toggleThemeMode} />}
+          label={`Dark mode is ${isDarkModeEnabled ? 'enabled' : 'disabled'}`} />
       </DialogContent>
       <DialogActions>
         <Button disabled={settings.isWaniKaniEnabled && !(validableAPIKey?.isValid)} onClick={proceedButtonOnClick}>Save Settings</Button>

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -46,6 +46,7 @@ export type SettingsType = {
     isValid: boolean,
     errorMessage: string,
   },
+  isDarkModeEnabled: boolean,
 };
 
 export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings}: 
@@ -58,6 +59,7 @@ export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings
   const initialSettings = {
     isWaniKaniEnabled: savedSettings?.isWaniKaniEnabled || false,
     validableAPIKey: savedSettings?.waniKaniAPIKey ? {value: savedSettings?.waniKaniAPIKey, isValid: isValidAPIKey(savedSettings?.waniKaniAPIKey), errorMessage: ""} : undefined,
+    isDarkModeEnabled: savedSettings?.isDarkModeEnabled || false,
   };
   const [settings, setSettings] = useState<SettingsType>(initialSettings);
   const {palette: {mode: themeMode}} = useTheme();
@@ -106,7 +108,13 @@ export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings
     }));
   };
 
-  const {isWaniKaniEnabled, validableAPIKey} = settings;
+  const onDarkModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    themeContext.toggleThemeMode();
+    setSettings(prevState => ({
+      ...prevState,
+      isDarkModeEnabled: event.target.checked,
+    }));
+  };
 
   const proceedButtonOnClick = () => {
     onSubmit(settings);
@@ -117,6 +125,9 @@ export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings
     // return state to initial settings
     setSettings(initialSettings);
   };
+
+
+  const {isWaniKaniEnabled, validableAPIKey} = settings;
 
   return (
       <Dialog open={isOpen} onClose={onDialogClose}>
@@ -151,7 +162,7 @@ export default function SettingsDialog({isOpen, onClose, onSubmit, savedSettings
         </Typography>
         <FormControlLabel 
           control={<Switch checked={isDarkModeEnabled} 
-          onChange={themeContext.toggleThemeMode} />}
+          onChange={onDarkModeChange} />}
           label={`Dark mode is ${isDarkModeEnabled ? 'enabled' : 'disabled'}`} />
       </DialogContent>
       <DialogActions>

--- a/components/ThemeContext.tsx
+++ b/components/ThemeContext.tsx
@@ -10,17 +10,18 @@ const ThemeContext = createContext({
 export const ThemeContextProvider: React.FC<{children?: React.ReactNode}> = ({children}) => {
     const [savedSettings, _] = useSavedSettings();
     const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-    const [themeMode, setThemeMode] = useState<'light' | 'dark'>(prefersDarkMode ? 'dark' : 'light');
+    const [themeMode, setThemeMode] = useState<'light' | 'dark'>('light');
     const theme = useMemo(() => createTheme({palette: {mode: themeMode}}), [themeMode]);
     const toggleThemeMode = () => {
         setThemeMode(prevValue => prevValue === 'light' ? 'dark' : 'light');
     };
 
     useEffect(() => {
-        if (savedSettings?.isDarkModeEnabled) {
+        // saved settings has higher priority than system preference
+        if ((savedSettings?.isDarkModeEnabled === undefined && prefersDarkMode) || savedSettings?.isDarkModeEnabled) {
             setThemeMode('dark');
         }
-    }, [savedSettings?.isDarkModeEnabled]);
+    }, [savedSettings?.isDarkModeEnabled, prefersDarkMode]);
 
     return (
         <ThemeContext.Provider value={{toggleThemeMode}}>

--- a/components/ThemeContext.tsx
+++ b/components/ThemeContext.tsx
@@ -1,5 +1,6 @@
+import { useMediaQuery } from "@mui/material";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { createContext, useEffect, useState } from "react";
+import { createContext, useEffect, useMemo, useState } from "react";
 import useSavedSettings from "../libs/hooks/useSavedSettings";
 
 const ThemeContext = createContext({
@@ -7,11 +8,19 @@ const ThemeContext = createContext({
 });
 
 export const ThemeContextProvider: React.FC<{children?: React.ReactNode}> = ({children}) => {
-    const [themeMode, setThemeMode] = useState<'light' | 'dark'>('light');
-    const theme = createTheme({palette: {mode: themeMode}});
+    const [savedSettings, _] = useSavedSettings();
+    const prefersDarkMode = useMediaQuery(`(prefers-color-scheme): dark`);
+    const [themeMode, setThemeMode] = useState<'light' | 'dark'>(prefersDarkMode ? 'dark' : 'light');
+    const theme = useMemo(() => createTheme({palette: {mode: themeMode}}), [themeMode]);
     const toggleThemeMode = () => {
         setThemeMode(prevValue => prevValue === 'light' ? 'dark' : 'light');
     };
+
+    useEffect(() => {
+        if (savedSettings?.isDarkModeEnabled) {
+            setThemeMode('dark');
+        }
+    }, [savedSettings?.isDarkModeEnabled]);
 
     return (
         <ThemeContext.Provider value={{toggleThemeMode}}>

--- a/components/ThemeContext.tsx
+++ b/components/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import { useMediaQuery } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { createContext, useEffect, useMemo, useState } from "react";
 import useSavedSettings from "../libs/hooks/useSavedSettings";
@@ -9,7 +9,7 @@ const ThemeContext = createContext({
 
 export const ThemeContextProvider: React.FC<{children?: React.ReactNode}> = ({children}) => {
     const [savedSettings, _] = useSavedSettings();
-    const prefersDarkMode = useMediaQuery(`(prefers-color-scheme): dark`);
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
     const [themeMode, setThemeMode] = useState<'light' | 'dark'>(prefersDarkMode ? 'dark' : 'light');
     const theme = useMemo(() => createTheme({palette: {mode: themeMode}}), [themeMode]);
     const toggleThemeMode = () => {

--- a/components/ThemeContext.tsx
+++ b/components/ThemeContext.tsx
@@ -16,10 +16,12 @@ export const ThemeContextProvider: React.FC<{children?: React.ReactNode}> = ({ch
         setThemeMode(prevValue => prevValue === 'light' ? 'dark' : 'light');
     };
 
+    // saved settings should have higher priority than system preference
     useEffect(() => {
-        // saved settings has higher priority than system preference
         if ((savedSettings?.isDarkModeEnabled === undefined && prefersDarkMode) || savedSettings?.isDarkModeEnabled) {
             setThemeMode('dark');
+        } else {
+            setThemeMode('light');
         }
     }, [savedSettings?.isDarkModeEnabled, prefersDarkMode]);
 

--- a/components/ThemeContext.tsx
+++ b/components/ThemeContext.tsx
@@ -1,0 +1,25 @@
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import { createContext, useEffect, useState } from "react";
+import useSavedSettings from "../libs/hooks/useSavedSettings";
+
+const ThemeContext = createContext({
+    toggleThemeMode: () => {},
+});
+
+export const ThemeContextProvider: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    const [themeMode, setThemeMode] = useState<'light' | 'dark'>('light');
+    const theme = createTheme({palette: {mode: themeMode}});
+    const toggleThemeMode = () => {
+        setThemeMode(prevValue => prevValue === 'light' ? 'dark' : 'light');
+    };
+
+    return (
+        <ThemeContext.Provider value={{toggleThemeMode}}>
+            <ThemeProvider theme={theme}>
+                {children}
+            </ThemeProvider>
+        </ThemeContext.Provider>
+    );
+}
+
+export default ThemeContext;

--- a/libs/hooks/useSavedSettings.ts
+++ b/libs/hooks/useSavedSettings.ts
@@ -3,7 +3,7 @@ import {useState} from 'react';
 const localStorageKey = "SAVED_SETTINGS";
 
 export type SavedSettings = {
-    isWaniKaniEnabled: boolean,
+    isWaniKaniEnabled?: boolean,
     waniKaniAPIKey?: string,
 };
 

--- a/libs/hooks/useSavedSettings.ts
+++ b/libs/hooks/useSavedSettings.ts
@@ -5,6 +5,7 @@ const localStorageKey = "SAVED_SETTINGS";
 export type SavedSettings = {
     isWaniKaniEnabled?: boolean,
     waniKaniAPIKey?: string,
+    isDarkModeEnabled?: boolean,
 };
 
 // Reference: https://usehooks.com/useLocalStorage/

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,11 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
+import { ThemeContextProvider } from '../components/ThemeContext'
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return <ThemeContextProvider>
+    <Component {...pageProps} />
+  </ThemeContextProvider>
 }
 
 export default MyApp

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,6 +47,7 @@ const Home: NextPage = () => {
 
   const settingsSubmitHandler = (settings: SettingsType) => {
     setSavedSettings({
+      ...savedSettings,
       isWaniKaniEnabled: settings.isWaniKaniEnabled,
       waniKaniAPIKey: settings.validableAPIKey?.value,
     });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,6 +50,7 @@ const Home: NextPage = () => {
       ...savedSettings,
       isWaniKaniEnabled: settings.isWaniKaniEnabled,
       waniKaniAPIKey: settings.validableAPIKey?.value,
+      isDarkModeEnabled: settings.isDarkModeEnabled,
     });
     router.push("/");
   };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,13 +14,3 @@ a {
 * {
   box-sizing: border-box;
 }
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
-}


### PR DESCRIPTION
- prioritize saved settings (saved in browser's local storage) over system preference (i.e. based on `prefers-color-scheme` media query)