### PR TITLE
fix: replace unpkg with jsdelivr

### DIFF
--- a/download-dictionary.sh
+++ b/download-dictionary.sh
@@ -4,5 +4,5 @@ mkdir dict
 files=('base.dat.gz' 'cc.dat.gz' 'check.dat.gz' 'tid.dat.gz' 'tid_map.dat.gz' 'tid_pos.dat.gz' 'unk.dat.gz' 'unk_char.dat.gz' 'unk_compat.dat.gz' 'unk_invoke.dat.gz' 'unk_map.dat.gz' 'unk_pos.dat.gz')
 for i in "${files[@]}" 
 do
-    wget -O "dict/$i" -c "https://unpkg.com/kuromoji@0.1.2/dict/$i"
+    wget -O "dict/$i" -c "https://cdn.jsdelivr.net/npm/kuromoji@0.1.2/dict/$i"
 done


### PR DESCRIPTION
CDN for kuroshiro seems to be down: https://unpkg.com/browse/kuromoji@0.1.2/dict/